### PR TITLE
Verify the files that are bundled together exist.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
-var Glob = require('glob').Glob,
+var glob = require('glob'),
     fs = require('fs'),
     path = require('path'),
     _ = require('lodash'),
     useref = require('useref'),
     gulp = require('gulp'),
+    gutil = require('gulp-util'),
     gulpif = require('gulp-if'),
     concat = require('gulp-concat'),
     uglify = require('gulp-uglify'),
@@ -23,7 +24,7 @@ module.exports = function(globs, opt){
     }
 
     return function () {
-        return new Glob(globs, opt, function (err, files) {
+        return new glob.Glob(globs, opt, function (err, files) {
             _.forEach(files, function (p) {
                 var assets = useref(fs.readFileSync(path.normalize(p), { encoding: 'utf-8'}))[1];
                 var css = assets.css;
@@ -36,9 +37,20 @@ module.exports = function(globs, opt){
                     return paths;
                 }
 
+                function verifyPath(paths) {
+                    _.forEach(paths, function (val, i) {
+                        var isGlob = glob.sync(val).length > 1;
+                        if (!isGlob && !fs.existsSync(val)) {
+                            gutil.log('[bundle]' + gutil.colors.red('Warning: no file matches ' + val));
+                        }
+                    });
+                    return paths;
+                }
+
                 _.forEach(css, function (paths, name) {
                     if (name !== '' && paths.length) {
                         prefixPath(paths);
+                        verifyPath(paths);
 
                         return gulp.src(paths)
                             .pipe(concat(path.basename(name)))
@@ -50,6 +62,7 @@ module.exports = function(globs, opt){
                 _.forEach(js, function (paths, name) {
                     if (name !== '' && paths.length) {
                         prefixPath(paths);
+                        verifyPath(paths);
 
                         return gulp.src(paths)
                             .pipe(concat(path.basename(name)))

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "glob": "~3.2.8",
     "gulp": "~3.5.1",
+    "gulp-util": "~2.2.14",
     "gulp-concat": "~2.1.7",
     "gulp-if": "~0.0.5",
     "gulp-minify-css": "~0.3.0",


### PR DESCRIPTION
I believe that the code for this gulp extension was written using `gulp.src` for simplicity. While that works, `gulp.src` does glob matches, so `gulp-bundle` isn't emitting any error messages.

In working with the source, I realized that with this extension, you can use globs in your build blocks, so I went with that assumption. It's a nice feature of the project, but I don't know if it was intended.

Anyway, this will log error messages when files aren't found. It doesn't make it a hard error, though, so the task continues and concatenates whatever it did find (which is the current behavior).
